### PR TITLE
Enhance sinks to support idleness.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink/SinkWriter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink/SinkWriter.java
@@ -56,6 +56,15 @@ public interface SinkWriter<InputT, CommT, WriterStateT> extends AutoCloseable {
     default void writeWatermark(Watermark watermark) throws IOException {}
 
     /**
+     * Marks the writer as idle. This function is called when all sink inputs are idle.
+     *
+     * <p>A writer becomes active again as soon as a record or watermark is received.
+     *
+     * @throws Exception if fail to mark idle.
+     */
+    default void markIdle() throws Exception {}
+
+    /**
      * Prepare for a commit.
      *
      * <p>This will be called before we checkpoint the Writer's state in Streaming execution mode.

--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink/SinkWriter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink/SinkWriter.java
@@ -20,6 +20,7 @@
 package org.apache.flink.api.connector.sink;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.common.eventtime.Watermark;
 
 import java.io.IOException;
 import java.util.List;
@@ -45,6 +46,14 @@ public interface SinkWriter<InputT, CommT, WriterStateT> extends AutoCloseable {
      * @throws IOException if fail to add an element.
      */
     void write(InputT element, Context context) throws IOException;
+
+    /**
+     * Add a watermark to the writer.
+     *
+     * @param watermark The watermark.
+     * @throws IOException if fail to add a watermark.
+     */
+    default void processWatermark(Watermark watermark) throws IOException {}
 
     /**
      * Prepare for a commit.

--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink/SinkWriter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink/SinkWriter.java
@@ -53,7 +53,7 @@ public interface SinkWriter<InputT, CommT, WriterStateT> extends AutoCloseable {
      * @param watermark The watermark.
      * @throws IOException if fail to add a watermark.
      */
-    default void processWatermark(Watermark watermark) throws IOException {}
+    default void writeWatermark(Watermark watermark) throws IOException {}
 
     /**
      * Prepare for a commit.

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/StateBootstrapWrapperOperator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/StateBootstrapWrapperOperator.java
@@ -90,6 +90,11 @@ public final class StateBootstrapWrapperOperator<
     }
 
     @Override
+    public void markIdle() throws Exception {
+        operator.markIdle();
+    }
+
+    @Override
     public void processLatencyMarker(LatencyMarker latencyMarker) throws Exception {
         operator.processLatencyMarker(latencyMarker);
     }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/StateBootstrapWrapperOperator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/StateBootstrapWrapperOperator.java
@@ -90,8 +90,8 @@ public final class StateBootstrapWrapperOperator<
     }
 
     @Override
-    public void markIdle() throws Exception {
-        operator.markIdle();
+    public void processStreamStatus(StreamStatus status) throws Exception {
+        operator.processStreamStatus(status);
     }
 
     @Override

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/output/SnapshotUtilsTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/output/SnapshotUtilsTest.java
@@ -31,6 +31,8 @@ import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
+
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -147,8 +149,8 @@ public class SnapshotUtilsTest {
         }
 
         @Override
-        public void markIdle() throws Exception {
-            ACTUAL_ORDER_TRACKING.add("markIdle");
+        public void processStreamStatus(StreamStatus status) throws Exception {
+            ACTUAL_ORDER_TRACKING.add("processStreamStatus");
         }
     }
 }

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/output/SnapshotUtilsTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/output/SnapshotUtilsTest.java
@@ -145,5 +145,10 @@ public class SnapshotUtilsTest {
             ACTUAL_ORDER_TRACKING.add("getCurrentKey");
             return null;
         }
+
+        @Override
+        public void markIdle() throws Exception {
+            ACTUAL_ORDER_TRACKING.add("markIdle");
+        }
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/SinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/SinkFunction.java
@@ -57,7 +57,7 @@ public interface SinkFunction<IN> extends Function, Serializable {
      * @throws Exception This method may throw exceptions. Throwing an exception will cause the
      *     operation to fail and may trigger recovery.
      */
-    default void processWatermark(Watermark watermark) throws Exception {}
+    default void writeWatermark(Watermark watermark) throws Exception {}
 
     /**
      * Context that {@link SinkFunction SinkFunctions } can use for getting additional data about an

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/SinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/SinkFunction.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.api.functions.sink;
 
 import org.apache.flink.annotation.Public;
+import org.apache.flink.api.common.eventtime.Watermark;
 import org.apache.flink.api.common.functions.Function;
 
 import java.io.Serializable;
@@ -48,6 +49,15 @@ public interface SinkFunction<IN> extends Function, Serializable {
     default void invoke(IN value, Context context) throws Exception {
         invoke(value);
     }
+
+    /**
+     * Writes the given watermark to the sink. This function is called for every watermark.
+     *
+     * @param watermark The watermark.
+     * @throws Exception This method may throw exceptions. Throwing an exception will cause the
+     *     operation to fail and may trigger recovery.
+     */
+    default void processWatermark(Watermark watermark) throws Exception {}
 
     /**
      * Context that {@link SinkFunction SinkFunctions } can use for getting additional data about an

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/SinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/SinkFunction.java
@@ -60,6 +60,16 @@ public interface SinkFunction<IN> extends Function, Serializable {
     default void writeWatermark(Watermark watermark) throws Exception {}
 
     /**
+     * Marks the sink as idle. This function is called when all sink inputs are idle.
+     *
+     * <p>A sink becomes active again as soon as a record or watermark is received.
+     *
+     * @throws Exception This method may throw exceptions. Throwing an exception will cause the
+     *     operation to fail and may trigger recovery.
+     */
+    default void markIdle() throws Exception {}
+
+    /**
      * Context that {@link SinkFunction SinkFunctions } can use for getting additional data about an
      * input record.
      *

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -661,6 +661,9 @@ public abstract class AbstractStreamOperator<OUT>
     }
 
     @Override
+    public void markIdle() throws Exception {}
+
+    @Override
     public OperatorID getOperatorID() {
         return config.getOperatorID();
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -639,7 +639,7 @@ public abstract class AbstractStreamOperator<OUT>
     }
 
     public final void emitStreamStatus(StreamStatus streamStatus) throws Exception {
-        output.emitStreamStatus(streamStatus);
+        processStreamStatus(streamStatus);
     }
 
     private void emitStreamStatus(StreamStatus streamStatus, int index) throws Exception {
@@ -648,7 +648,7 @@ public abstract class AbstractStreamOperator<OUT>
             processWatermark(new Watermark(combinedWatermark.getCombinedWatermark()));
         }
         if (wasIdle != combinedWatermark.isIdle()) {
-            output.emitStreamStatus(streamStatus);
+            processStreamStatus(streamStatus);
         }
     }
 
@@ -661,7 +661,9 @@ public abstract class AbstractStreamOperator<OUT>
     }
 
     @Override
-    public void markIdle() throws Exception {}
+    public void processStreamStatus(StreamStatus status) throws Exception {
+        output.emitStreamStatus(status);
+    }
 
     @Override
     public OperatorID getOperatorID() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
@@ -536,12 +536,14 @@ public abstract class AbstractStreamOperatorV2<OUT>
             processWatermark(new Watermark(combinedWatermark.getCombinedWatermark()));
         }
         if (wasIdle != combinedWatermark.isIdle()) {
-            output.emitStreamStatus(streamStatus);
+            processStreamStatus(streamStatus);
         }
     }
 
     @Override
-    public void markIdle() throws Exception {}
+    public void processStreamStatus(StreamStatus status) throws Exception {
+        output.emitStreamStatus(status);
+    }
 
     @Override
     public OperatorID getOperatorID() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
@@ -541,6 +541,9 @@ public abstract class AbstractStreamOperatorV2<OUT>
     }
 
     @Override
+    public void markIdle() throws Exception {}
+
+    @Override
     public OperatorID getOperatorID() {
         return config.getOperatorID();
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperator.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
 import org.apache.flink.util.Disposable;
 
 import java.io.Serializable;
@@ -139,11 +140,13 @@ public interface StreamOperator<OUT>
     // ------------------------------------------------------------------------
 
     /**
-     * Marks the operator as idle due to a stream status change.
+     * This method is called when a stream status change on the operator input(s) causes
+     * an overall status change to the operator, e.g. when all inputs transition to idle.
+     *
      * @throws Exception Throwing an exception here causes the operator to fail and go into
      *     recovery.
      */
-    void markIdle() throws Exception;
+    void processStreamStatus(StreamStatus status) throws Exception;
 
     // ------------------------------------------------------------------------
     //  miscellaneous

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperator.java
@@ -133,6 +133,18 @@ public interface StreamOperator<OUT>
     /** Provides a context to initialize all state in the operator. */
     void initializeState(StreamTaskStateInitializer streamTaskStateManager) throws Exception;
 
+
+    // ------------------------------------------------------------------------
+    //  Watermark handling
+    // ------------------------------------------------------------------------
+
+    /**
+     * Marks the operator as idle due to a stream status change.
+     * @throws Exception Throwing an exception here causes the operator to fail and go into
+     *     recovery.
+     */
+    void markIdle() throws Exception;
+
     // ------------------------------------------------------------------------
     //  miscellaneous
     // ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSink.java
@@ -70,6 +70,12 @@ public class StreamSink<IN> extends AbstractUdfStreamOperator<Object, SinkFuncti
                 new org.apache.flink.api.common.eventtime.Watermark(mark.getTimestamp()));
     }
 
+    @Override
+    public void markIdle() throws Exception {
+        super.markIdle();
+        userFunction.markIdle();
+    }
+
     private class SimpleContext<IN> implements SinkFunction.Context {
 
         private StreamRecord<IN> element;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSink.java
@@ -66,7 +66,7 @@ public class StreamSink<IN> extends AbstractUdfStreamOperator<Object, SinkFuncti
     public void processWatermark(Watermark mark) throws Exception {
         super.processWatermark(mark);
         this.currentWatermark = mark.getTimestamp();
-        userFunction.processWatermark(
+        userFunction.writeWatermark(
                 new org.apache.flink.api.common.eventtime.Watermark(mark.getTimestamp()));
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSink.java
@@ -22,6 +22,7 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 
 /** A {@link StreamOperator} for executing {@link SinkFunction SinkFunctions}. */
@@ -71,9 +72,11 @@ public class StreamSink<IN> extends AbstractUdfStreamOperator<Object, SinkFuncti
     }
 
     @Override
-    public void markIdle() throws Exception {
-        super.markIdle();
-        userFunction.markIdle();
+    public void processStreamStatus(StreamStatus status) throws Exception {
+        super.processStreamStatus(status);
+        if (status.isIdle()) {
+            userFunction.markIdle();
+        }
     }
 
     private class SimpleContext<IN> implements SinkFunction.Context {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSink.java
@@ -66,6 +66,8 @@ public class StreamSink<IN> extends AbstractUdfStreamOperator<Object, SinkFuncti
     public void processWatermark(Watermark mark) throws Exception {
         super.processWatermark(mark);
         this.currentWatermark = mark.getTimestamp();
+        userFunction.processWatermark(
+                new org.apache.flink.api.common.eventtime.Watermark(mark.getTimestamp()));
     }
 
     private class SimpleContext<IN> implements SinkFunction.Context {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractSinkWriterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractSinkWriterOperator.java
@@ -90,7 +90,7 @@ abstract class AbstractSinkWriterOperator<InputT, CommT> extends AbstractStreamO
     public void processWatermark(Watermark mark) throws Exception {
         super.processWatermark(mark);
         this.currentWatermark = mark.getTimestamp();
-        sinkWriter.processWatermark(
+        sinkWriter.writeWatermark(
                 new org.apache.flink.api.common.eventtime.Watermark(mark.getTimestamp()));
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractSinkWriterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractSinkWriterOperator.java
@@ -95,6 +95,12 @@ abstract class AbstractSinkWriterOperator<InputT, CommT> extends AbstractStreamO
     }
 
     @Override
+    public void markIdle() throws Exception {
+        super.markIdle();
+        sinkWriter.markIdle();
+    }
+
+    @Override
     public void endInput() throws Exception {
         sendCommittables(sinkWriter.prepareCommit(true));
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractSinkWriterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractSinkWriterOperator.java
@@ -90,6 +90,8 @@ abstract class AbstractSinkWriterOperator<InputT, CommT> extends AbstractStreamO
     public void processWatermark(Watermark mark) throws Exception {
         super.processWatermark(mark);
         this.currentWatermark = mark.getTimestamp();
+        sinkWriter.processWatermark(
+                new org.apache.flink.api.common.eventtime.Watermark(mark.getTimestamp()));
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractSinkWriterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractSinkWriterOperator.java
@@ -28,6 +28,7 @@ import org.apache.flink.streaming.api.operators.InternalTimerService;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 
 import java.util.List;
@@ -95,9 +96,11 @@ abstract class AbstractSinkWriterOperator<InputT, CommT> extends AbstractStreamO
     }
 
     @Override
-    public void markIdle() throws Exception {
-        super.markIdle();
-        sinkWriter.markIdle();
+    public void processStreamStatus(StreamStatus status) throws Exception {
+        super.processStreamStatus(status);
+        if (status.isIdle()) {
+            sinkWriter.markIdle();
+        }
     }
 
     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamSinkOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamSinkOperatorTest.java
@@ -79,6 +79,15 @@ public class StreamSinkOperatorTest extends TestLogger {
                         new Tuple4<>(42L, 15L, 13L, "Ciao"),
                         new Tuple4<>(42L, 15L, null, "Ciao")));
 
+        assertThat(bufferingSink.watermarks.size(), is(3));
+
+        assertThat(
+                bufferingSink.watermarks,
+                contains(
+                        new org.apache.flink.api.common.eventtime.Watermark(17L),
+                        new org.apache.flink.api.common.eventtime.Watermark(42L),
+                        new org.apache.flink.api.common.eventtime.Watermark(42L)));
+
         testHarness.close();
     }
 
@@ -87,8 +96,11 @@ public class StreamSinkOperatorTest extends TestLogger {
         // watermark, processing-time, timestamp, event
         private final List<Tuple4<Long, Long, Long, T>> data;
 
+        private final List<org.apache.flink.api.common.eventtime.Watermark> watermarks;
+
         public BufferingQueryingSink() {
             data = new ArrayList<>();
+            watermarks = new ArrayList<>();
         }
 
         @Override
@@ -109,6 +121,12 @@ public class StreamSinkOperatorTest extends TestLogger {
                                 null,
                                 value));
             }
+        }
+
+        @Override
+        public void processWatermark(org.apache.flink.api.common.eventtime.Watermark watermark)
+                throws Exception {
+            watermarks.add(watermark);
         }
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamSinkOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamSinkOperatorTest.java
@@ -124,7 +124,7 @@ public class StreamSinkOperatorTest extends TestLogger {
         }
 
         @Override
-        public void processWatermark(org.apache.flink.api.common.eventtime.Watermark watermark)
+        public void writeWatermark(org.apache.flink.api.common.eventtime.Watermark watermark)
                 throws Exception {
             watermarks.add(watermark);
         }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
@@ -216,7 +216,7 @@ public class TestSink implements Sink<Integer, String, String, String> {
         }
 
         @Override
-        public void processWatermark(Watermark watermark) throws IOException {
+        public void writeWatermark(Watermark watermark) throws IOException {
             watermarks.add(watermark);
         }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.runtime.operators.sink;
 
+import org.apache.flink.api.common.eventtime.Watermark;
 import org.apache.flink.api.connector.sink.Committer;
 import org.apache.flink.api.connector.sink.GlobalCommitter;
 import org.apache.flink.api.connector.sink.Sink;
@@ -199,16 +200,24 @@ public class TestSink implements Sink<Integer, String, String, String> {
 
         protected List<String> elements;
 
+        protected List<Watermark> watermarks;
+
         protected ProcessingTimeService processingTimerService;
 
         DefaultSinkWriter() {
             this.elements = new ArrayList<>();
+            this.watermarks = new ArrayList<>();
         }
 
         @Override
         public void write(Integer element, Context context) {
             elements.add(
                     Tuple3.of(element, context.timestamp(), context.currentWatermark()).toString());
+        }
+
+        @Override
+        public void processWatermark(Watermark watermark) throws IOException {
+            watermarks.add(watermark);
         }
 
         @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
@@ -607,7 +607,7 @@ public class SubtaskCheckpointCoordinatorTest {
         public void processWatermark(Watermark mark) throws Exception {}
 
         @Override
-        public void markIdle() throws Exception {}
+        public void processStreamStatus(StreamStatus status) throws Exception {}
 
         @Override
         public void processLatencyMarker(LatencyMarker latencyMarker) {}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
@@ -607,6 +607,9 @@ public class SubtaskCheckpointCoordinatorTest {
         public void processWatermark(Watermark mark) throws Exception {}
 
         @Override
+        public void markIdle() throws Exception {}
+
+        @Override
         public void processLatencyMarker(LatencyMarker latencyMarker) {}
 
         @Override

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/api/FileReadingWatermarkITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/api/FileReadingWatermarkITCase.java
@@ -108,7 +108,7 @@ public class FileReadingWatermarkITCase {
             public void invoke(String value, SinkFunction.Context context) {}
 
             @Override
-            public void processWatermark(Watermark watermark) throws Exception {
+            public void writeWatermark(Watermark watermark) throws Exception {
                 if (watermark.getTimestamp() != lastWatermark) {
                     lastWatermark = watermark.getTimestamp();
                     numWatermarks.add(1);

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/api/FileReadingWatermarkITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/api/FileReadingWatermarkITCase.java
@@ -19,6 +19,7 @@ package org.apache.flink.test.streaming.api;
 
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.accumulators.IntCounter;
+import org.apache.flink.api.common.eventtime.Watermark;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
@@ -104,9 +105,12 @@ public class FileReadingWatermarkITCase {
             }
 
             @Override
-            public void invoke(String value, SinkFunction.Context context) {
-                if (context.currentWatermark() != lastWatermark) {
-                    lastWatermark = context.currentWatermark();
+            public void invoke(String value, SinkFunction.Context context) {}
+
+            @Override
+            public void processWatermark(Watermark watermark) throws Exception {
+                if (watermark.getTimestamp() != lastWatermark) {
+                    lastWatermark = watermark.getTimestamp();
                     numWatermarks.add(1);
                 }
             }


### PR DESCRIPTION
## What is the purpose of the change

Propagates the idleness signal to the `SinkFunction` and `SinkWriter` for connector-specific purposes such as watermark propagation across pipelines.

## Brief change log

- Add `processStreamStatus()` method to `StreamOperator` interface with default implementation
- Update abstract stream operator to invoke `processStreamStatus` when the combined input changes.
- Add `markIdle()` method to `SinkFunction` interface
- Add `markIdle()` method to `SinkWriter` interface
- Add support to sink operators for invoking `markIdle()` on sink functions.


## Verifying this change

(TODO) This change adds tests for idleness callbacks, and verifies exception handling behavior.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
