### PR TITLE
[SQL Connector] Fix catalog default-database creation

### DIFF
--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/catalog/PulsarCatalog.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/catalog/PulsarCatalog.java
@@ -123,7 +123,7 @@ public class PulsarCatalog extends GenericInMemoryCatalog {
         CatalogDatabaseImpl defaultDatabase =
                 new CatalogDatabaseImpl(new HashMap<>(), "The default database for PulsarCatalog");
         try {
-            createDatabase(catalogConfiguration.get(DEFAULT_DATABASE), defaultDatabase, true);
+            createDatabase(getDefaultDatabase(), defaultDatabase, true);
         } catch (DatabaseAlreadyExistException e) {
             throw new CatalogException(
                     "Error: should ignore default database if not exist instead of throwing exception");

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/catalog/PulsarCatalog.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/catalog/PulsarCatalog.java
@@ -53,8 +53,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 
-import static org.apache.flink.connector.pulsar.table.catalog.PulsarCatalogFactoryOptions.DEFAULT_DATABASE;
-
 /**
  * Catalog implementation to use Pulsar to store metadatas for Flink tables/databases.
  *


### PR DESCRIPTION
The `default-database` option is not copied to `catalogConfiguration` so when the catalog opens the option is not taken into account to create the namespace in Pulsar (a namespace `default_database` is always created)
Instead we can get it from the `PulsarCatalog` itself.